### PR TITLE
add Invert filter and Outline filter

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -198,7 +198,7 @@ blur_radius_slider.grid_remove()
 # Dropdown for filter selection
 filter_label = ttk.Label(frame, text="Select a Filter:")
 filter_label.grid(row=4, column=0, pady=5)
-filter_menu = ttk.OptionMenu(frame, filter_option, "None", "None", "Cool Tone", "Warm Tone", "Vintage Tone", "High Contrast")
+filter_menu = ttk.OptionMenu(frame, filter_option, "None", "None", "Cool Tone", "Warm Tone", "Vintage Tone", "High Contrast", "Invert", "Outline")
 filter_menu.grid(row=4, column=1, padx=5)
 
 # Dropdown for shape mask selection

--- a/src/tools/image_filter_color.py
+++ b/src/tools/image_filter_color.py
@@ -2,7 +2,6 @@ from enum import Enum
 import numpy as np
 import cv2
 from tools.grayscale import rgb_to_grayscale
-from tools.blur import apply_blur
 
 class FilterType(Enum):
     COOL_TONE = "Cool Tone"
@@ -72,10 +71,9 @@ def apply_outline(image: np.ndarray) -> np.ndarray:
     :return: Image with outline effect applied.
     """
 
-    gray = rgb_to_grayscale(image)
-    #Convert to grayscale for Easy to edge detection 
-    #it reduces the complexity of processing three color channels (BGR) to just one channel (grayscale).
-
+    grayscale_image = rgb_to_grayscale(image)  # Change variable name to grayscale_image
+    # Convert to grayscale for easier edge detection 
+    # It reduces the complexity of processing three color channels (BGR) to just one channel (grayscale).
 
     # Define Sobel kernels for edge detection
     sobel_x = np.array([[1, 0, -1],
@@ -87,23 +85,23 @@ def apply_outline(image: np.ndarray) -> np.ndarray:
                         [-1, -2, -1]], dtype=np.float32)  # Vertical edges
 
     # Get image dimensions
-    height, width = gray.shape
+    height, width = grayscale_image.shape
 
     # Create an empty array for the output image
-    outline_image = np.zeros_like(gray)
+    outline_image = np.zeros_like(grayscale_image)
 
     # Apply the Sobel filter to detect edges
     for y in range(1, height - 1):
         for x in range(1, width - 1):
             # Convolution for Sobel X
-            gx = (sobel_x[0, 0] * gray[y - 1, x - 1] + sobel_x[0, 1] * gray[y - 1, x] + sobel_x[0, 2] * gray[y - 1, x + 1] +
-                  sobel_x[1, 0] * gray[y, x - 1] + sobel_x[1, 1] * gray[y, x] + sobel_x[1, 2] * gray[y, x + 1] +
-                  sobel_x[2, 0] * gray[y + 1, x - 1] + sobel_x[2, 1] * gray[y + 1, x] + sobel_x[2, 2] * gray[y + 1, x + 1])
+            gx = (sobel_x[0, 0] * grayscale_image[y - 1, x - 1] + sobel_x[0, 1] * grayscale_image[y - 1, x] + sobel_x[0, 2] * grayscale_image[y - 1, x + 1] +
+                  sobel_x[1, 0] * grayscale_image[y, x - 1] + sobel_x[1, 1] * grayscale_image[y, x] + sobel_x[1, 2] * grayscale_image[y, x + 1] +
+                  sobel_x[2, 0] * grayscale_image[y + 1, x - 1] + sobel_x[2, 1] * grayscale_image[y + 1, x] + sobel_x[2, 2] * grayscale_image[y + 1, x + 1])
             
             # Convolution for Sobel Y
-            gy = (sobel_y[0, 0] * gray[y - 1, x - 1] + sobel_y[0, 1] * gray[y - 1, x] + sobel_y[0, 2] * gray[y - 1, x + 1] +
-                  sobel_y[1, 0] * gray[y, x - 1] + sobel_y[1, 1] * gray[y, x] + sobel_y[1, 2] * gray[y, x + 1] +
-                  sobel_y[2, 0] * gray[y + 1, x - 1] + sobel_y[2, 1] * gray[y + 1, x] + sobel_y[2, 2] * gray[y + 1, x + 1])
+            gy = (sobel_y[0, 0] * grayscale_image[y - 1, x - 1] + sobel_y[0, 1] * grayscale_image[y - 1, x] + sobel_y[0, 2] * grayscale_image[y - 1, x + 1] +
+                  sobel_y[1, 0] * grayscale_image[y, x - 1] + sobel_y[1, 1] * grayscale_image[y, x] + sobel_y[1, 2] * grayscale_image[y, x + 1] +
+                  sobel_y[2, 0] * grayscale_image[y + 1, x - 1] + sobel_y[2, 1] * grayscale_image[y + 1, x] + sobel_y[2, 2] * grayscale_image[y + 1, x + 1])
             
             # Calculate gradient magnitude
             magnitude = np.sqrt(gx ** 2 + gy ** 2)
@@ -112,7 +110,7 @@ def apply_outline(image: np.ndarray) -> np.ndarray:
     # Normalize the outline image to the range [0, 255] for calculate threshold value 
     outline_image = (outline_image / outline_image.max() * 255).astype(np.uint8)
 
-    # grayscale outline image is converted back to a 3-channel BGR image
+    # Grayscale outline image is converted back to a 3-channel BGR image
     color_outline_image = cv2.cvtColor(outline_image, cv2.COLOR_GRAY2BGR)
 
     # Set a threshold to keep only significant edges
@@ -120,6 +118,7 @@ def apply_outline(image: np.ndarray) -> np.ndarray:
     color_outline_image[mask == 0] = (255, 255, 255)  # (And below 50 are set to white)
 
     return color_outline_image
+
 
 def apply_rgb_adjustment(image: np.ndarray, scaling: tuple, offset: tuple) -> np.ndarray:
     """

--- a/src/tools/image_filter_color.py
+++ b/src/tools/image_filter_color.py
@@ -1,12 +1,16 @@
 from enum import Enum
 import numpy as np
 import cv2
+from tools.grayscale import rgb_to_grayscale
+from tools.blur import apply_blur
 
 class FilterType(Enum):
     COOL_TONE = "Cool Tone"
     WARM_TONE = "Warm Tone"
     VINTAGE_TONE = "Vintage Tone"
     HIGH_CONTRAST = "High Contrast"
+    INVERT = "Invert"
+    OUTLINE = "Outline"
 
 FILTER_SETTINGS = {
     FilterType.COOL_TONE: {
@@ -24,6 +28,14 @@ FILTER_SETTINGS = {
     FilterType.HIGH_CONTRAST: {
         'scaling': (1.5, 1.5, 1.5),
         'offset': (-50, -50, -50)
+    },
+    FilterType.INVERT: {    # Light areas in the original image become dark, and dark areas become light.
+        'scaling': (-1, -1, -1),  # Negative scaling to invert colors
+        'offset': (255, 255, 255)  # Offset so inverted value is in range [0, 255]
+    },
+    FilterType.OUTLINE: {
+        'scaling': (0, 0, 0),    # Remove color, focus on edges
+        'offset': (255, 255, 255)   # Turn edges to white (outline effect)
     }
 }
 
@@ -39,10 +51,75 @@ def apply_filter(image: np.ndarray, filter_type: FilterType) -> np.ndarray:
     if len(image.shape) == 2:
         image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
+    # Check for the INVERT filter type
+    if filter_type == FilterType.INVERT:
+        return cv2.bitwise_not(image)  # Invert colors directly Ex. image(50, 100, 150) invert is image(255-50, 255-100, 255-150)
+    
+    # Check for the OUTLINE filter type
+    if filter_type == FilterType.OUTLINE:
+        return apply_outline(image)
+
     # Retrieve filter settings for the specified filter type
     settings = FILTER_SETTINGS[filter_type]
     
     return apply_rgb_adjustment(image, settings['scaling'], settings['offset'])
+
+def apply_outline(image: np.ndarray) -> np.ndarray:
+    """
+    Apply an outline effect to the image using a Sobel filter for edge detection.
+    
+    :param image: Input image in BGR format (height, width, 3).
+    :return: Image with outline effect applied.
+    """
+
+    gray = rgb_to_grayscale(image)
+    #Convert to grayscale for Easy to edge detection 
+    #it reduces the complexity of processing three color channels (BGR) to just one channel (grayscale).
+
+
+    # Define Sobel kernels for edge detection
+    sobel_x = np.array([[1, 0, -1],
+                        [2, 0, -2],
+                        [1, 0, -1]], dtype=np.float32)  # Horizontal edges
+
+    sobel_y = np.array([[1, 2, 1],
+                        [0, 0, 0],
+                        [-1, -2, -1]], dtype=np.float32)  # Vertical edges
+
+    # Get image dimensions
+    height, width = gray.shape
+
+    # Create an empty array for the output image
+    outline_image = np.zeros_like(gray)
+
+    # Apply the Sobel filter to detect edges
+    for y in range(1, height - 1):
+        for x in range(1, width - 1):
+            # Convolution for Sobel X
+            gx = (sobel_x[0, 0] * gray[y - 1, x - 1] + sobel_x[0, 1] * gray[y - 1, x] + sobel_x[0, 2] * gray[y - 1, x + 1] +
+                  sobel_x[1, 0] * gray[y, x - 1] + sobel_x[1, 1] * gray[y, x] + sobel_x[1, 2] * gray[y, x + 1] +
+                  sobel_x[2, 0] * gray[y + 1, x - 1] + sobel_x[2, 1] * gray[y + 1, x] + sobel_x[2, 2] * gray[y + 1, x + 1])
+            
+            # Convolution for Sobel Y
+            gy = (sobel_y[0, 0] * gray[y - 1, x - 1] + sobel_y[0, 1] * gray[y - 1, x] + sobel_y[0, 2] * gray[y - 1, x + 1] +
+                  sobel_y[1, 0] * gray[y, x - 1] + sobel_y[1, 1] * gray[y, x] + sobel_y[1, 2] * gray[y, x + 1] +
+                  sobel_y[2, 0] * gray[y + 1, x - 1] + sobel_y[2, 1] * gray[y + 1, x] + sobel_y[2, 2] * gray[y + 1, x + 1])
+            
+            # Calculate gradient magnitude
+            magnitude = np.sqrt(gx ** 2 + gy ** 2)
+            outline_image[y, x] = np.clip(magnitude, 0, 255)
+
+    # Normalize the outline image to the range [0, 255] for calculate threshold value 
+    outline_image = (outline_image / outline_image.max() * 255).astype(np.uint8)
+
+    # grayscale outline image is converted back to a 3-channel BGR image
+    color_outline_image = cv2.cvtColor(outline_image, cv2.COLOR_GRAY2BGR)
+
+    # Set a threshold to keep only significant edges
+    mask = (outline_image > 50).astype(np.uint8)  # (If outline_image > 50 are considered edges )
+    color_outline_image[mask == 0] = (255, 255, 255)  # (And below 50 are set to white)
+
+    return color_outline_image
 
 def apply_rgb_adjustment(image: np.ndarray, scaling: tuple, offset: tuple) -> np.ndarray:
     """


### PR DESCRIPTION
Invert filter formula :
Inverted Color = 255 − Original Color

Outline filter :
step1 - Convert image to grayscale for Easy to edge detection (reduce complexity from 3 color channel(RGB) to 1 channel(grayscale))

step2 - define sobel kernel in horizortal and vertical edges

step3 - matrix convolution between sobel kernel and image

step4 - calculate threshold value (for separate edge and non-edge) and convert image back to RGB channel

---------------------------------------------------------------------------------------------------------------------------------------------

This pull request introduces two new filter types, "Invert" and "Outline," to the image filtering functionality. The changes include updates to the filter selection UI, the filter type enumeration, and the filter application logic, along with the addition of a new function for the outline effect.

### Enhancements to Image Filtering:

* **UI Update for Filter Selection**:
  - Added "Invert" and "Outline" options to the filter dropdown menu in `src/main.py`. (`src/main.py`)

* **Filter Type Enumeration**:
  - Added `INVERT` and `OUTLINE` to the `FilterType` enumeration in `src/tools/image_filter_color.py`. (`src/tools/image_filter_color.py`)

* **Filter Settings**:
  - Defined settings for `INVERT` and `OUTLINE` filter types. (`src/tools/image_filter_color.py`)

* **Filter Application Logic**:
  - Updated `apply_filter` function to handle `INVERT` and `OUTLINE` filter types. (`src/tools/image_filter_color.py`)

* **Outline Effect Implementation**:
  - Added `apply_outline` function to implement the outline effect using Sobel edge detection. (`src/tools/image_filter_color.py`)